### PR TITLE
Append groups when doing ensure-groups

### DIFF
--- a/overlay/usr/bin/ensure-groups
+++ b/overlay/usr/bin/ensure-groups
@@ -39,7 +39,7 @@ groups=$(join_by "," "${!group_map[@]}")
 if [ "$groups" != "" ]; then
     echo "Adding user '${USER}' to groups: $groups"
 
-    usermod -G $groups ${USER}
+    usermod -a -G $groups ${USER}
 else
     echo "Not modifying user groups ($groups)"
 fi


### PR DESCRIPTION
This PR appends the groups when ensure-groups is called rather than replacing them.